### PR TITLE
Edit nft arweave upload workflow and script

### DIFF
--- a/tools/scripts/nft/arweave-upload.js
+++ b/tools/scripts/nft/arweave-upload.js
@@ -26,9 +26,18 @@ async function uploadNFT(filePath){
     console.log('Loading file from path ', filePath);
     const key = JSON.parse(fs.readFileSync('./.secrets/arweave/deployer.json', 'utf8'));
     const filename = path.parse(path.basename(filePath)).name;
-    const metadataPath = `./tools/scripts/nft/metadata/${filename}.json`;
+    const metadataPath = `./tools/scripts/nft/metadata-template.json`;
+    const attributesPath = `./tools/scripts/nft/metadata/${filename}.json`;
     console.log(`Reading metadata from path: ${metadataPath}`);
-    const metadata = JSON.parse(fs.readFileSync(metadataPath, 'utf8'));
+    let metadata = JSON.parse(fs.readFileSync(metadataPath, 'utf8'));
+    const attributes = JSON.parse(fs.readFileSync(attributesPath, 'utf8'));
+    // const nftNumber = filename.substring(
+    //     filename.indexOf("_") + 1,
+    //     filename.length
+    // );
+    metadata.attributes = attributes.attributes;
+    // metadata.name = `THE TRADER - Player #${nftNumber}/100`
+    console.log(`NFT name: ${metadata.name}`)
 
     const file = fs.readFileSync(filePath);
 

--- a/tools/scripts/nft/metadata-template.json
+++ b/tools/scripts/nft/metadata-template.json
@@ -1,0 +1,5 @@
+{
+  "description": "This CryptoWolf is a true Wolf of DeFi. He puts his liquidity where his mouth is.",
+  "external_url": "https://deltaprime.io/",
+  "name":"THE PROVIDER - Original Depositor"
+}

--- a/tools/scripts/nft/metadata/nft_depositor_example_attributes.json
+++ b/tools/scripts/nft/metadata/nft_depositor_example_attributes.json
@@ -1,0 +1,40 @@
+{
+  "attributes": [
+    {
+      "trait_type": "body",
+      "value": "Charcoal grey"
+    },
+    {
+      "trait_type": "shirt",
+      "value": "White"
+    },
+    {
+      "trait_type": "suit",
+      "value": "Black"
+    },
+    {
+      "trait_type": "head",
+      "value": "Charcoal grey"
+    },
+    {
+      "trait_type": "tie",
+      "value": "Green"
+    },
+    {
+      "trait_type": "extras",
+      "value": "none"
+    },
+    {
+      "trait_type": "glasses",
+      "value": "Monocle"
+    },
+    {
+      "trait_type": "jewelry",
+      "value": "none"
+    },
+    {
+      "trait_type": "wearables",
+      "value": "none"
+    }
+  ]
+}


### PR DESCRIPTION
This PR introduces changes to tools/scripts/nft folder structure and arweave-upload script.
It allows for matching unique attributes json files per image/video file (with the same name) and adding those attributes to a "base json metadata template". 
Moreover it supports embedding the #editionNumber into the NFT metadata `name` property.