### PR TITLE
fix: exposure update for gmx deposit & withdraw(callback included)

### DIFF
--- a/contracts/facets/arbitrum/GmxV2FacetArbitrum.sol
+++ b/contracts/facets/arbitrum/GmxV2FacetArbitrum.sol
@@ -88,7 +88,7 @@ contract GmxV2FacetArbitrum is GmxV2Facet {
     function depositArbUsdcGmxV2(bool isLongToken, uint256 tokenAmount, uint256 minGmAmount, uint256 executionFee) external payable {
         address _depositedToken = isLongToken ? ARB : USDC;
 
-        _deposit(GM_ARB_ARB_USDC, isLongToken ? ARB : USDC, tokenAmount, minGmAmount, executionFee);
+        _deposit(GM_ARB_ARB_USDC, _depositedToken, tokenAmount, minGmAmount, executionFee);
     }
 
     function depositLinkUsdcGmxV2(bool isLongToken, uint256 tokenAmount, uint256 minGmAmount, uint256 executionFee) external payable {

--- a/contracts/interfaces/ITokenManager.sol
+++ b/contracts/interfaces/ITokenManager.sol
@@ -10,6 +10,11 @@ interface ITokenManager {
         uint256 debtCoverage;
     }
 
+    struct Exposure {
+        uint256 current;
+        uint256 max; // Setting max to 0 means no exposure limitations.
+    }
+
     function activateToken ( address token ) external;
     function addPoolAssets ( poolAsset[] memory poolAssets ) external;
     function addTokenAssets ( Asset[] memory tokenAssets ) external;
@@ -33,6 +38,8 @@ interface ITokenManager {
     function setDebtCoverageStaked ( bytes32 stakedAsset, uint256 coverage ) external;
     function supportedTokensList ( uint256 ) external view returns ( address );
     function tokenAddressToSymbol ( address ) external view returns ( bytes32 );
+    function identifierToExposureGroup ( bytes32 ) external view returns ( bytes32 );
+    function groupToExposure ( bytes32 ) external view returns ( Exposure memory);
     function tokenToStatus ( address ) external view returns ( uint256 );
     function transferOwnership ( address newOwner ) external;
 }


### PR DESCRIPTION
Updated the exposure from the deposit and withdraw callback.
Deposit and withdraw token amounts were fetched from the event logs from the callback methods.